### PR TITLE
use 'builder' API for constructing client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  ignore:
+    - dependency-name: dtolnay/rust-toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+name: Continuous integration
+
+jobs:
+  test:
+    name: test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [msrv, stable, nightly, macos, windows]
+        include:
+          - build: msrv
+            os: ubuntu-latest
+            rust: 1.60.0
+          - build: stable
+            os: ubuntu-latest
+            rust: stable
+          - build: nightly
+            os: ubuntu-latest
+            rust: nightly
+          - build: macos
+            os: macos-latest
+            rust: stable
+          - build: windows
+            os: windows-latest
+            rust: stable
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo test
+
+  fmt:
+    name: format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ readme = "README.md"
 categories = ["api-bindings"]
 license = "MIT OR Apache-2.0"
 
+rust-version = "1.60.0"
+
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ export NEOHUB_TOKEN=69696969-6969-4969-6969-696969696969
 
 Then, you can use the library:
 ```rust
-let mut client = Client::from_env()?;
+let mut client = Client::from_env()?.connect().await?;
 let result: Value = client.command_void(commands::GET_LIVE_DATA).await?;
 println!("{}", result.to_string()));
 ```

--- a/examples/dump-live-data.rs
+++ b/examples/dump-live-data.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     let unix_millis = now();
     let writer = fs::File::create(format!("logs.{unix_millis}.jsonl.zstd"))?;
     let mut writer = zstd::Encoder::new(writer, 9)?;
-    let mut client = neohub::Client::from_env()?;
+    let mut client = neohub::Client::from_env()?.connect().await?;
     loop {
         let live_data: Value = client.command_void(neohub::commands::GET_LIVE_DATA).await?;
         writer.write_all(format!("{} ", now()).as_bytes())?;

--- a/examples/neohub-cli.rs
+++ b/examples/neohub-cli.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 #[tokio::main]
 async fn main() -> Result<()> {
     pretty_env_logger::init();
-    let mut client = neohub::Client::from_env()?;
+    let mut client = neohub::Client::from_env()?.connect().await?;
     println!("Attempting to connect...");
     println!(
         "{:?}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ impl Client {
         arg: &str,
     ) -> Result<T> {
         let (_, resp) = self
-            .raw_message(&format!("{{'{}':'{}'}}", command, arg))
+            .raw_message(&format!("{{'{command}':'{arg}'}}"))
             .await?;
         serde_json::from_str(&resp).with_context(|| anyhow!("reading {:?}", resp))
     }
@@ -161,7 +161,7 @@ impl Client {
 
 #[inline]
 fn serialise_void(command: &str) -> String {
-    format!("{{'{}':0}}", command)
+    format!("{{'{command}':0}}")
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
this is an experiment (which is why it's a 'draft') of introducing a 'builder' API for constructing the client.

The primary motivation is to provide a cleaner interface when using options.

right now the API for constructing a client with options looks something like

```rust
let mut client = Client::new_opts(URL, TOKEN, Opts { timeout: Duration::from_secs(10), ..Opts::default() } )?;
```

with a builder API this looks like the following-

```rust
let mut client = Client::build(URL, TOKEN)
    .timeout(Duration::from_secs(10))
    .connect()
    .await?;
```